### PR TITLE
WIP: feat(fetch): proof of concept `fetch` module implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,10 +69,12 @@ dependencies = [
 name = "draco"
 version = "0.1.0"
 dependencies = [
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "int_hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -120,6 +122,11 @@ dependencies = [
 [[package]]
 name = "fuchsia-zircon-sys"
 version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "futures"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -373,6 +380,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.27 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +503,7 @@ dependencies = [
 "checksum failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "64c2d913fe8ed3b6c6518eedf4538255b989945c14c2a7d5cbff62a5e2120596"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+"checksum futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "49e7653e374fe0d0c12de4250f0bdb60680b8c80eed558c5c7538eec9c89e21b"
 "checksum heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea04fa3ead4e05e51a7c806fc07271fdbde4e246a6c6d1efd52e72230b771b82"
 "checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
 "checksum int_hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "82b10fb1274dcd264c1ca312b5d672dac395f696ebd383833ace2ddec4afe961"
@@ -519,6 +537,7 @@ dependencies = [
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum wasm-bindgen 0.2.27 (registry+https://github.com/rust-lang/crates.io-index)" = "ddabe7a233fc293b35f9754067580906c14b5a14b68da67d21ac109f8624c3fe"
 "checksum wasm-bindgen-backend 0.2.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4420cb4101491fa91a0aa488584bf359ec4d805667982d3de37ad18c1adc6c62"
+"checksum wasm-bindgen-futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "510541c3a3e13763785f6066ad8823f522fc214f867c1af9469092a5f740230f"
 "checksum wasm-bindgen-macro 0.2.27 (registry+https://github.com/rust-lang/crates.io-index)" = "83b50f7b3fad6acd49da239daf5a7a358c554e94e904549f4fd2d7a34d692fb0"
 "checksum wasm-bindgen-macro-support 0.2.27 (registry+https://github.com/rust-lang/crates.io-index)" = "a0970181097265052ae1822d0203412ab7ca5a0f05b8d6581c23ec31e9b99b95"
 "checksum wasm-bindgen-shared 0.2.27 (registry+https://github.com/rust-lang/crates.io-index)" = "251fcb2edbdc5baace161ed8ab680c6cd0ff35b50bdf3eb21afb81fd42c0eb78"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,11 @@ description = "Draco is a Rust library for building client side web applications
 license = "MIT/Apache-2.0"
 
 [dependencies]
+futures = "0.1.25"
 int_hash = "0.1.1"
 js-sys = "0.3"
 wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.3"
 
 [dependencies.web-sys]
 version = "0.3"
@@ -27,6 +29,10 @@ features = [
     "Node",
     "NodeList",
     "Performance",
+    "Request",
+    "RequestInit",
+    "RequestMode",
+    "Response",
     "Storage",
     "Text",
     "Window",

--- a/Rakefile
+++ b/Rakefile
@@ -7,11 +7,11 @@ task :default do
     name = File.basename(name)
     dir = "target/examples/#{name}"
     mkdir_p dir
-    sh "wasm-bindgen target/wasm32-unknown-unknown/release/examples/#{name}.wasm --out-dir #{dir} --no-modules --no-modules-global #{name}"
+    sh "wasm-bindgen target/wasm32-unknown-unknown/release/examples/#{name}.wasm --out-dir #{dir} --no-modules --no-modules-global Example"
     File.write "#{dir}/index.html", <<HTML
 <main></main>
 <script src="#{name}.js"></script>
-<script>#{name}("#{name}_bg.wasm").then(() => #{name}.start());</script>
+<script>Example("#{name}_bg.wasm").then(() => Example.start());</script>
 HTML
     index << <<HTML
 <h3><a href="./#{name}/index.html">#{name}</a></h3>

--- a/examples/fetch.rs
+++ b/examples/fetch.rs
@@ -1,0 +1,62 @@
+use wasm_bindgen::prelude::*;
+
+type Response = Result<String, draco::fetch::Error>;
+
+#[derive(Debug)]
+pub struct Fetch {
+    url: String,
+    response: Option<Response>,
+}
+
+impl Fetch {
+    fn new() -> Self {
+        Fetch {
+            url: "https://api.github.com/repos/rust-lang/rust/branches/master".into(),
+            response: None,
+        }
+    }
+}
+
+pub enum Message {
+    Send,
+    UpdateResponse(Response),
+    UpdateUrl(String),
+}
+
+impl draco::App for Fetch {
+    type Message = Message;
+
+    fn update(&mut self, mailbox: &draco::Mailbox<Message>, message: Self::Message) {
+        use self::Message::*;
+        match message {
+            Send => {
+                mailbox.spawn(
+                    draco::fetch::get(&self.url).send::<draco::fetch::Text>(),
+                    Message::UpdateResponse,
+                );
+            }
+            UpdateResponse(response) => self.response = Some(response),
+            UpdateUrl(url) => self.url = url,
+        }
+    }
+
+    fn render(&self) -> draco::Node<Self::Message> {
+        use draco::html as h;
+        h::div()
+            .push(
+                h::input()
+                    .attr("value", self.url.clone())
+                    .on_input(Message::UpdateUrl),
+            )
+            .push(h::button().push("GET").on("click", |_| Message::Send))
+            .push(h::pre().push(format!("{:#?}", self)))
+            .into()
+    }
+}
+
+#[wasm_bindgen]
+pub fn start() {
+    draco::start(Fetch::new(), draco::select("main").expect("main").into());
+}
+
+pub fn main() {}

--- a/examples/jfb.html
+++ b/examples/jfb.html
@@ -8,6 +8,6 @@
   <body>
     <main></main>
     <script src="jfb.js"></script>
-    <script>jfb("jfb_bg.wasm").then(() => jfb.start());</script>
+    <script>Example("jfb_bg.wasm").then(() => Example.start());</script>
   </body>
 </html>

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -1,0 +1,64 @@
+use futures::Future;
+use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen_futures::JsFuture;
+use web_sys as web;
+
+#[derive(Debug)]
+pub struct Request {
+    method: String,
+    url: String,
+}
+
+impl Request {
+    pub fn new(method: &str, url: &str) -> Request {
+        Request {
+            method: method.into(),
+            url: url.into(),
+        }
+    }
+
+    pub fn send<R: Response>(self) -> impl Future<Item = R::Item, Error = Error> {
+        let mut init = web::RequestInit::new();
+        init.method(&self.method);
+        let request = web::Request::new_with_str_and_init(&self.url, &init).unwrap();
+        let promise = web::window().unwrap().fetch_with_request(&request);
+        R::send(JsFuture::from(promise).map(|response| {
+            assert!(response.is_instance_of::<web::Response>());
+            response.dyn_into::<web::Response>().unwrap()
+        }))
+    }
+}
+
+#[derive(Debug)]
+pub struct Error(JsValue);
+
+pub trait Response {
+    type Item;
+
+    fn send(
+        future: impl Future<Item = web::Response, Error = JsValue> + 'static,
+    ) -> Box<Future<Item = Self::Item, Error = Error>>;
+}
+
+#[derive(Debug)]
+pub struct Text;
+
+impl Response for Text {
+    type Item = String;
+
+    fn send(
+        future: impl Future<Item = web::Response, Error = JsValue> + 'static,
+    ) -> Box<Future<Item = Self::Item, Error = Error>> {
+        Box::new(
+            future
+                .and_then(|response| response.text())
+                .and_then(JsFuture::from)
+                .map(|text| text.as_string().unwrap())
+                .map_err(Error),
+        )
+    }
+}
+
+pub fn get(url: &str) -> Request {
+    Request::new("GET", url)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 pub mod console;
 pub mod app;
 pub mod element;
+pub mod fetch;
 pub mod html;
 pub mod mailbox;
 pub mod node;


### PR DESCRIPTION
This is a very simple wrapper for `fetch`, powered by futures 0.1. The `Mailbox` struct now has a `spawn` function that takes any `Future` and sends its return value as a message to the application.