### PR TITLE
Makes after-update re-render optional

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -7,7 +7,7 @@ use web_sys as web;
 pub trait App: Sized + 'static {
     type Message;
 
-    fn update(&mut self, _mailbox: &Mailbox<Self::Message>, _message: Self::Message) {}
+    fn update(&mut self, _mailbox: &Mailbox<Self::Message>, _message: Self::Message) -> bool {false}
     fn render(&self) -> Node<Self::Message>;
 }
 
@@ -31,13 +31,16 @@ impl<A: App> Instance<A> {
         }
         self.inner.is_updating.replace(true);
         let mailbox = self.mailbox();
-        self.inner.app.borrow_mut().update(&mailbox, message);
+        let mut redraw = false;
+        redraw |= self.inner.app.borrow_mut().update(&mailbox, message);
         while !self.inner.queue.borrow().is_empty() {
             let message = self.inner.queue.borrow_mut().remove(0);
-            self.inner.app.borrow_mut().update(&mailbox, message);
+            redraw |= self.inner.app.borrow_mut().update(&mailbox, message);
         }
         self.inner.is_updating.replace(false);
-        self.render();
+        if redraw {
+            self.render();
+        }
     }
 
     fn render(&self) {


### PR DESCRIPTION
I was in need of such feature so i added it, but not sure if it's suitable for master branch. Examples remains unchanged, so if it's Ok to merge i'll update examples.