### PR TITLE
Pass though actual fetch error status and message

### DIFF
--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -51,7 +51,17 @@ impl Response for Text {
     ) -> Box<Future<Item = Self::Item, Error = Error>> {
         Box::new(
             future
-                .and_then(|response| response.text())
+                .and_then(|response| {
+                    if response.ok() {
+                        Ok(response)
+                    } else {
+                        let err = format!("{} ({})", response.status(), response.status_text());
+                        Err(JsValue::from_str(&err))
+                    }
+                })
+                .and_then(|response| {
+                    response.text()
+                })
                 .and_then(JsFuture::from)
                 .map(|text| text.as_string().unwrap())
                 .map_err(Error),


### PR DESCRIPTION
Previously when server was responding with 4xx error (for example) `Response` value was Ok("").