### PR TITLE
Replace int_hash::IntHashMap with rustc_hash::FxHashMap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,10 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 futures = "0.1.25"
-int_hash = "0.1.1"
 js-sys = "0.3"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.3"
+rustc-hash = "1.0.1"
 
 [dependencies.web-sys]
 version = "0.3"

--- a/src/element.rs
+++ b/src/element.rs
@@ -1,9 +1,9 @@
 use crate::{Mailbox, Node, S};
-use int_hash::IntHashMap;
 use std::rc::Rc;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use web_sys as web;
+use rustc_hash::FxHashMap;
 
 pub type NonKeyedElement<Message> = Element<NonKeyed<Message>>;
 pub type KeyedElement<Message> = Element<Keyed<Message>>;
@@ -483,7 +483,7 @@ impl<Message: 'static> Children for Keyed<Message> {
         if new.is_empty() && old.is_empty() {
             return;
         }
-        let mut key_to_old_index = IntHashMap::default();
+        let mut key_to_old_index = FxHashMap::default();
         for (index, (key, _)) in (skip..).zip(old.iter_mut()) {
             key_to_old_index.insert(key.clone(), index);
         }


### PR DESCRIPTION
The int_hash crate was yanked from crates.io.
rustc_hash also provides a fast hash map suitable for the purpose.

Closes #16 .